### PR TITLE
change drag.start() to drag.exec_()

### DIFF
--- a/qtpandas_1.0.4/qtpandas/views/DataTableView.py
+++ b/qtpandas_1.0.4/qtpandas/views/DataTableView.py
@@ -63,7 +63,7 @@ class DragTable(QtGui.QTableView):
         pixmap = QtGui.QPixmap(":/icons/insert-table.png")
         drag.setHotSpot(QtCore.QPoint(pixmap.width()/3, pixmap.height()/3))
         drag.setPixmap(pixmap)
-        result = drag.start(Qt.MoveAction)
+        result = drag.exec_(Qt.MoveAction)
 
     def mouseMoveEvent(self, event):
         super(DragTable, self).mouseMoveEvent(event)

--- a/qtpandas_1.0.4/qtpandas/views/EditDialogs.py
+++ b/qtpandas_1.0.4/qtpandas/views/EditDialogs.py
@@ -14,7 +14,7 @@ from qtpandas.models.SupportedDtypes import SupportedDtypes
 
 import numpy
 from pandas import Timestamp
-from pandas.tslib import NaTType
+from pandas._libs.tslibs.nattype import NaTType
 import warnings
 
 class DefaultValueValidator(QtGui.QValidator):


### PR DESCRIPTION
$ python run.py
Traceback (most recent call last):
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python36\lib\site-packages\qtpandas\views\DataTableView.py", line 70, in mouseMoveEvent
    self.startDrag(self.indexAt(event.pos()))
  File "C:\Users\Administrator\AppData\Local\Programs\Python\Python36\lib\site-packages\qtpandas\views\DataTableView.py", line 66, in startDrag
    result = drag.start(Qt.MoveAction)
AttributeError: 'QDrag' object has no attribute 'start'